### PR TITLE
Print out a pun for passed, failing, pending specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
   - 2.2
   - 2.1
+before_install:
+  - gem install bundler -v "~> 1.9"
 sudo: false
 notifications:
   email: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/pain_in_the_rspec.rb
+++ b/lib/pain_in_the_rspec.rb
@@ -1,2 +1,3 @@
 require "pain_in_the_rspec/version"
 require "pain_in_the_rspec/pundit"
+require "pain_in_the_rspec/formatter"

--- a/lib/pain_in_the_rspec.rb
+++ b/lib/pain_in_the_rspec.rb
@@ -1,5 +1,2 @@
 require "pain_in_the_rspec/version"
-
-module PainInTheRspec
-  # Your code goes here...
-end
+require "pain_in_the_rspec/pundit"

--- a/lib/pain_in_the_rspec/formatter.rb
+++ b/lib/pain_in_the_rspec/formatter.rb
@@ -1,0 +1,5 @@
+module PainInTheRspec
+  class Formatter < RSpec::Core::Formatters::DocumentationFormatter
+    # RSpec::Core::Formatters.register Formatter, :example_passed, :example_failed
+  end
+end

--- a/lib/pain_in_the_rspec/formatter.rb
+++ b/lib/pain_in_the_rspec/formatter.rb
@@ -1,5 +1,50 @@
+require "rspec/core/formatters/base_text_formatter"
+
 module PainInTheRspec
   class Formatter < RSpec::Core::Formatters::DocumentationFormatter
-    RSpec::Core::Formatters.register Formatter, :example_passed, :example_failed
+    RSpec::Core::Formatters.register self, :example_passed, :example_pending,
+      :example_failed
+
+    def example_failed(failure)
+      output.puts failure_output(
+        failure.example,
+        failure.example.execution_result.exception
+      )
+    end
+
+    def example_passed(passed)
+      output.puts passed_output(passed.example)
+    end
+
+    private
+
+    def passed_output(example)
+      wrap(pun_description(example), :success)
+    end
+
+    def pending_output(example, message)
+      wrap(
+        "#{pun_description(example)} (PENDING: #{message})",
+        :pending
+      )
+    end
+
+    def failure_output(example, _exception)
+      message = pun_description(example)
+
+      wrap(
+        "#{message} (FAILED - #{next_failure_index})",
+        :failure
+      )
+    end
+
+    def pun_description(example)
+      current_indentation +
+        Pundit.new(example.description.strip).pun
+    end
+
+    def wrap(message, status)
+      RSpec::Core::Formatters::ConsoleCodes.wrap(message, status)
+    end
   end
 end

--- a/lib/pain_in_the_rspec/formatter.rb
+++ b/lib/pain_in_the_rspec/formatter.rb
@@ -1,5 +1,5 @@
 module PainInTheRspec
   class Formatter < RSpec::Core::Formatters::DocumentationFormatter
-    # RSpec::Core::Formatters.register Formatter, :example_passed, :example_failed
+    RSpec::Core::Formatters.register Formatter, :example_passed, :example_failed
   end
 end

--- a/lib/pain_in_the_rspec/pundit.rb
+++ b/lib/pain_in_the_rspec/pundit.rb
@@ -1,0 +1,17 @@
+require "girls_just_want_to_have_puns"
+
+module PainInTheRspec
+  class Pundit
+    def initialize(original)
+      @original = original
+    end
+
+    def pun
+      GirlsJustWantToHavePuns.pun(original).new_phrase
+    end
+
+    private
+
+    attr_reader :original
+  end
+end

--- a/pain_in_the_rspec.gemspec
+++ b/pain_in_the_rspec.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rspec-core", "~> 3.0"
+  spec.add_dependency "girls_just_want_to_have_puns"
+
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/pain_in_the_rspec/formatter_spec.rb
+++ b/spec/pain_in_the_rspec/formatter_spec.rb
@@ -4,8 +4,74 @@ require "stringio"
 describe PainInTheRspec::Formatter do
   let(:output) { StringIO.new }
 
-  it "prints out a pun when an example passes" do
-    GirlsJustWantToHavePuns.pun("keyword"
-    Musip
+  it "prints out a pun when an example fails" do
+    pundit = instance_double(PainInTheRspec::Pundit)
+    allow(pundit).to receive(:pun).and_return("pain in the neck")
+    allow(PainInTheRspec::Pundit).to receive(:new).with("rspec").and_return(pundit)
+
+    example = double(
+      "example",
+      description: "rspec",
+      execution_result: execution_result(status: :failed, exception: Exception.new)
+    )
+
+    allow(RSpec.configuration).to receive(:color_enabled?).and_return(false)
+    setup_reporter
+
+    send_notification(:example_failed, example_notification(example))
+
+    expect(output.string).to include "pain in the neck"
+  end
+
+  def execution_result(values)
+    RSpec::Core::Example::ExecutionResult.new.tap do |er|
+      values.each { |name, value| er.__send__(:"#{name}=", value) }
+    end
+  end
+
+  def example_notification(example)
+    ::RSpec::Core::Notifications::ExampleNotification.for example
+  end
+
+  def new_example(description, metadata = {})
+    metadata = metadata.dup
+    result = RSpec::Core::Example::ExecutionResult.new
+    result.started_at = ::Time.now
+    result.record_finished(metadata.delete(:status) { :passed }, ::Time.now)
+    result.exception = Exception.new if result.status == :failed
+
+    instance_double(
+      RSpec::Core::Example,
+      description: description,
+      full_description: description,
+      execution_result: result,
+      location: "",
+      location_rerun_argument: "",
+      metadata: { shared_group_inclusion_backtrace: [] }.merge(metadata)
+    )
+  end
+
+  def formatter
+    @formatter ||= setup_reporter
+  end
+
+  def setup_reporter
+    config.add_formatter described_class
+    @reporter = config.reporter
+    config.formatters.first
+  end
+
+  def send_notification(type, notification)
+    @reporter.notify(type, notification)
+  end
+
+  def config
+    @configuration ||=
+      begin
+        config = RSpec::Core::Configuration.new
+        config.output_stream = output
+        config.color = false
+        config
+      end
   end
 end

--- a/spec/pain_in_the_rspec/formatter_spec.rb
+++ b/spec/pain_in_the_rspec/formatter_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+require "stringio"
+
+describe PainInTheRspec::Formatter do
+  let(:output) { StringIO.new }
+
+  it "prints out a pun when an example passes" do
+    GirlsJustWantToHavePuns.pun("keyword"
+    Musip
+  end
+end

--- a/spec/pain_in_the_rspec/pundit_spec.rb
+++ b/spec/pain_in_the_rspec/pundit_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe PainInTheRspec::Pundit do
+  context "#pun" do
+    it "generates a pun" do
+      original = "hello"
+      pundit = described_class.new(original)
+      allow(GirlsJustWantToHavePuns).to receive(:pun).and_call_original
+
+      expect(pundit.pun).not_to eq original
+    end
+
+    it "uses Girls Just Want to Have Puns" do
+      original = "hello"
+      pundit = described_class.new(original)
+      allow(GirlsJustWantToHavePuns).to receive(:pun).and_call_original
+
+      pundit.pun
+
+      expect(GirlsJustWantToHavePuns).to have_received(:pun)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+$LOAD_PATH << File.expand_path("../lib", __FILE__)
+
+require "pain_in_the_rspec"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
The entire spec description is fed to the pun generator, which isn't really
ideal.